### PR TITLE
depend on mesalock-linux forks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,19 @@ keywords = ["tools", "webassembly", "wasm"]
 
 [dependencies]
 wabt-sys = { path = "wabt-sys", version = "0.5.3" }
-serde_json = "1.0"
-serde_derive = "1.0"
-serde = "1.0"
+serde_json = { git = "https://github.com/mesalock-linux/serde-json-sgx"}
+serde_derive = { git = "https://github.com/mesalock-linux/serde-sgx", default-features = false}
+serde = { git = "https://github.com/mesalock-linux/serde-sgx", default-features = false}
+
+[features]
+default = ["std", "mesalock_sgx"]
+
+mesalock_sgx = [
+  "serde/mesalock_sgx",
+  "serde_json/mesalock_sgx"
+]
+
+std = [
+  "serde/std",
+  "serde_json/std"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,5 +26,4 @@ mesalock_sgx = [
 
 std = [
   "serde/std",
-  "serde_json/std"
 ]


### PR DESCRIPTION
It seems real porting to mesalock deps has been missing. couldn't test this yet - which means it almost certainly wont work